### PR TITLE
[Feat/#3] Github API 데이터 처리를 위한 프로토타입 Demo 서버 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+
+	// basic spring web package dependency
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// dependency for dynamic webpage
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/softgallery/profilegameserverdemo/controller/GithubAPIController.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/controller/GithubAPIController.java
@@ -9,15 +9,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class GithubAPIController {
     private final GithubAPIService githubAPIService = new GithubAPIService();
 
-    @GetMapping("/github/{name}")
-    public String printGithubProfile(@PathVariable("name") String name) {
+    @GetMapping("/commit/{name}")
+    public String getCommitInfoByName(@PathVariable("name") String name) {
         System.out.println(name);
-        String repo = "spring-roomescape-playground";
+        String repo = "spring-roomescape-playground";   // repo 이름을 수정하여 넣을 것
 
-        return printCommitInfo(name, repo);
-    }
-
-    private String printCommitInfo(String owner, String repo) {
-        return githubAPIService.getCommits(owner, repo);
+        return githubAPIService.getCommits(name, repo);
     }
 }

--- a/src/main/java/com/softgallery/profilegameserverdemo/controller/GithubAPIController.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/controller/GithubAPIController.java
@@ -1,0 +1,23 @@
+package com.softgallery.profilegameserverdemo.controller;
+
+import com.softgallery.profilegameserverdemo.service.GithubAPIService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GithubAPIController {
+    private final GithubAPIService githubAPIService = new GithubAPIService();
+
+    @GetMapping("/github/{name}")
+    public String printGithubProfile(@PathVariable("name") String name) {
+        System.out.println(name);
+        String repo = "spring-roomescape-playground";
+
+        return printCommitInfo(name, repo);
+    }
+
+    private String printCommitInfo(String owner, String repo) {
+        return githubAPIService.getCommits(owner, repo);
+    }
+}

--- a/src/main/java/com/softgallery/profilegameserverdemo/controller/MainController.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/controller/MainController.java
@@ -1,0 +1,30 @@
+package com.softgallery.profilegameserverdemo.controller;
+
+import com.softgallery.profilegameserverdemo.domain.Profile;
+import com.softgallery.profilegameserverdemo.service.ProfileService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MainController {
+    private final ProfileService profileService = new ProfileService();
+
+    @GetMapping("/")
+    public String test() { return "test"; }
+
+    @GetMapping("/{name}")
+    @ResponseBody
+    public Profile searchProfile(@PathVariable("name") String name) {
+        System.out.println(name);
+
+        return profileService.getProfile(name);
+    }
+
+    @GetMapping("/profile")
+    @ResponseBody
+    public Profile printProfile() {
+        return new Profile(0L, "Jaehoon", "00:01:02", "2024-01-01");
+    }
+}

--- a/src/main/java/com/softgallery/profilegameserverdemo/controller/MainController.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/controller/MainController.java
@@ -2,12 +2,13 @@ package com.softgallery.profilegameserverdemo.controller;
 
 import com.softgallery.profilegameserverdemo.domain.Profile;
 import com.softgallery.profilegameserverdemo.service.ProfileService;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@Controller
 public class MainController {
     private final ProfileService profileService = new ProfileService();
 

--- a/src/main/java/com/softgallery/profilegameserverdemo/domain/Profile.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/domain/Profile.java
@@ -1,0 +1,34 @@
+package com.softgallery.profilegameserverdemo.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class Profile {
+    private final Long id;
+    private final String name;
+    private final LocalTime recentTime;
+    private final LocalDate recentDate;
+
+    public Profile(final Long id, final String name, final String time, final String date) {
+        this.id = id;
+        this.name = name;
+        this.recentTime = LocalTime.parse(time);
+        this.recentDate = LocalDate.parse(date);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalTime getRecentTime() {
+        return recentTime;
+    }
+
+    public LocalDate getRecentDate() {
+        return recentDate;
+    }
+}

--- a/src/main/java/com/softgallery/profilegameserverdemo/service/GithubAPIService.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/service/GithubAPIService.java
@@ -1,0 +1,18 @@
+package com.softgallery.profilegameserverdemo.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class GithubAPIService {
+    private final String GITHUB_API_URL = "https://api.github.com";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public GithubAPIService() { }
+
+    public String getCommits(String owner, String repo) {
+        String url = GITHUB_API_URL + "/repos/" + owner + "/" + repo + "/commits";
+        return restTemplate.getForObject(url, String.class);
+    }
+}

--- a/src/main/java/com/softgallery/profilegameserverdemo/service/ProfileService.java
+++ b/src/main/java/com/softgallery/profilegameserverdemo/service/ProfileService.java
@@ -1,0 +1,34 @@
+package com.softgallery.profilegameserverdemo.service;
+
+import com.softgallery.profilegameserverdemo.domain.Profile;
+import java.util.ArrayList;
+
+public class ProfileService {
+    private final ArrayList<Profile> profiles = new ArrayList<>();
+
+    public ProfileService() {
+        initialize();
+    }
+
+    // Initialization with test-cases
+    private void initialize() {
+        profiles.add(new Profile(1L, "Jaehoon", "00:01:02", "2024-01-01"));
+        profiles.add(new Profile(2L, "SHKim55", "23:00:00", "2024-12-23"));
+        profiles.add(new Profile(3L, "Sumin", "22:00:00", "2023-12-23"));
+        profiles.add(new Profile(4L, "YongWoo", "21:00:00", "2023-11-23"));
+        profiles.add(new Profile(5L, "Hangyul", "20:00:00", "2023-10-23"));
+    }
+
+    public ArrayList<Profile> getAllProfiles() {
+        return profiles;
+    }
+
+    // Find profile by name
+    public Profile getProfile(String name) {
+        for(Profile profile : profiles) {
+            if (profile.getName().equals(name))
+                return profile;
+        }
+        return new Profile(0L, "No Such User", "00:00:00", "0000-00-00");
+    }
+}

--- a/src/main/resources/templates/test.html
+++ b/src/main/resources/templates/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Page</title>
+</head>
+<body>
+ Testing
+</body>
+</html>


### PR DESCRIPTION
## 구현사항
- 서버의 동작 결과를 보여줄 test page 생성
- Service 내 테스트 데이터 기반 CRUD 일부 기능 구현 (C, R)
-  GitHub API로 데이터 요청 (commit 데이터)
- 요청 받은 API 데이터 페이지에 출력

## 설계 중점사항
- Spring LayredArchitecture 적용을 위해 구현 코드를 Controller/Service/Domain/Others(Exception 등)로 구분
(참고: https://hudi.blog/layered-architecture/)
- 깃허브 API 관련 Controller 로직은 MainController에서 분리하여 작성

## 기타 사항 및 향후 발전 방향성
- 현재 빠른 기술 시현만을 위해 아키텍쳐 및 객체지향적 설계, 코드 컨벤션 등을 일체 고려하지 않은 raw code임을 인지하고 리뷰해주셨으면 좋겠습니다.
- 코드를 실행하면 단순히 api에서 가져온 데이터를 String을 변환하여 출력하는 것 밖에 없기 때문에 추후에 정제 작업이 들어갈 예정입니다.
- 페이지에 표시할 내용, API에서 가져올 데이터 범위, 항목별 가중치를 통한 유저 경험치 설정 등 좀 더 세부적인 기획안이 나온 이후에 추가 구현이 가능할 것으로 보입니다.
- 전체적인 Code Convention, Documentation Convention (PR, Issue, commit log 작성 포함)과 같은 협업 세부사항 또한 다음 회의에서 정해져야 될 것 같습니다.
